### PR TITLE
Fix CircleCI testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,17 +21,8 @@ jobs:
             conda config --add channels bioconda
             conda config --set always_yes yes --set changeps1 no
             conda activate
-            mamba create -n confindr -c olcbioinformatics python=3.9.15
+            mamba create -n confindr bioconda::confindr=0.8.1
             source activate confindr
-            mamba install \
-              "bbmap>=38" \
-              "mash>=2.0" \
-              "kma>=1.2.0" \
-              "samtools>=1.6" \
-              "pysam>=0.15" \
-              "biopython=1.81" \
-              "pytest"
-            pip install -e .
             wget https://figshare.com/ndownloader/files/41228577 -O test_samples.tar.gz && \
               tar -xzvf test_samples.tar.gz && \
               mv test_samples/ tests/ && \

--- a/tests/test_confindr.py
+++ b/tests/test_confindr.py
@@ -28,7 +28,7 @@ def test_integration():
                       'SRX5084940_SRR8268052': 'Listeria',
                       'SRX5084941_SRR8268051': 'Listeria',
                       'SRX5084995_SRR8267997': 'Salmonella:Citrobacter'}
-    subprocess.call("confindr.py -i tests/test_samples -o confindr_integration_output -d databases -k",
+    subprocess.call("confindr.py -i tests/test_samples -o confindr_integration_output -d databases -k -Xmx 6g",
                      shell=True)
     with open('confindr_integration_output/confindr_report.csv') as csvfile:
         reader = csv.DictReader(csvfile)


### PR DESCRIPTION
- Changed the installation method of ConFindr to Bioconda recipe for CircleCI testing.
- Enforced `-Xmx` to prevent error every 5 samples during CircleCI testing.