### PR TITLE
docs: add Biocontainers Docker; fix pkg_resources (fixes #53, #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ ConFindr has only been validated using rMLST databases. **Please use them if pos
 
 ### Installing ConFindr
 
+#### Option A: Conda (recommended)
+
 1. Follow the instructions [here](https://bioconda.github.io/) to add the Bioconda channel to your list of conda channels, if it hasn't already been added.
 
 2. Install ConFindr into a new conda environment named 'confindr':
@@ -27,6 +29,22 @@ ConFindr has only been validated using rMLST databases. **Please use them if pos
 3. Activate the new conda environment:
 
 `conda activate confindr`
+
+#### Option B: Docker (Biocontainers)
+
+ConFindr is available as a Docker image from [Biocontainers](https://quay.io/organization/biocontainers). Pull and run:
+
+```bash
+docker pull quay.io/biocontainers/confindr:<tag>
+```
+
+Replace `<tag>` with a specific version tag (e.g. `0.8.2--pyhdfd78af_0`). Browse available tags at [quay.io/biocontainers/confindr/tags](https://quay.io/repository/biocontainers/confindr?tab=tags).
+
+Example run (mount your data and output directories):
+
+```bash
+docker run -v /path/to/input:/data -v /path/to/output:/output quay.io/biocontainers/confindr:<tag> confindr -i /data -o /output
+```
 
 ### Downloading and setting up the rMLST databases
 

--- a/confindr_src/methods.py
+++ b/confindr_src/methods.py
@@ -6,7 +6,7 @@ from itertools import chain
 from statistics import mean
 import multiprocessing
 import urllib.request
-import pkg_resources
+from importlib.metadata import version as get_package_version, PackageNotFoundError
 import numpy as np
 import subprocess
 import logging
@@ -1672,7 +1672,7 @@ def check_acceptable_xmx(xmx_string):
 
 def get_version():
     try:
-        version = 'ConFindr {}'.format(pkg_resources.get_distribution('confindr').version)
-    except pkg_resources.DistributionNotFound:
+        version = 'ConFindr {}'.format(get_package_version('confindr'))
+    except PackageNotFoundError:
         version = 'ConFindr (Unknown version)'
     return version

--- a/docs/install.md
+++ b/docs/install.md
@@ -59,6 +59,22 @@ find that it will automatically download to a folder called `.confindr_db` in yo
 
 Typing `confindr -h` into the command-line will show the help menu for the program. See the [Usage](usage.md) section for instructions on how to use ConFindr, including a ConFindr run on an example dataset.
 
+## Installing Using Docker (Biocontainers)
+
+ConFindr is available as a Docker image from [Biocontainers](https://quay.io/organization/biocontainers). Pull the image:
+
+```bash
+docker pull quay.io/biocontainers/confindr:<tag>
+```
+
+Replace `<tag>` with a specific version tag (e.g. `0.8.2--pyhdfd78af_0`). Browse available tags at [quay.io/biocontainers/confindr/tags](https://quay.io/repository/biocontainers/confindr?tab=tags).
+
+Example run (mount your data and output directories):
+
+```bash
+docker run -v /path/to/input:/data -v /path/to/output:/output quay.io/biocontainers/confindr:<tag> confindr -i /data -o /output
+```
+
 ## Manual Installation
 
 ### Executable

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 setup(
     name="confindr",
     version="0.8.2",
+    python_requires=">=3.8",
     packages=find_packages(),
     entry_points={
        'console_scripts': [


### PR DESCRIPTION
Closes #53
Closes #79

## Changes

### #53 - Add Biocontainers Docker to README and documentation
- Add Docker/Biocontainers installation section to README (Option B)
- Add equivalent section to docs/install.md
- Include pull command, tag browsing link, and example run with volume mounts

### #79 - Fix pkg_resources / setuptools downgrade issue
- Replace `pkg_resources.get_distribution` with `importlib.metadata.version`
- Add `python_requires=">=3.8"` for importlib.metadata compatibility
- Resolves `ModuleNotFoundError: No module named 'pkg_resources'` with modern setuptools (no need to downgrade to 69.5.1)
